### PR TITLE
Added new functionality for moving horizontally

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,25 @@
 # move
 
-It's annoying to delete and paste parts of a text just to move it up and down a
-bit. There is the `:m[ove]` command but it is quite awkward to use by todays
+It's annoying to delete and paste parts of a text just to move it up/down or
+left/right a bit.
+There is the `:m[ove]` command but it is quite awkward to use by todays
 standards. vim-move is a Vim plugin that moves lines and selections in a more
 visual manner. Out of the box, the following keys are mapped in visual and
 normal mode:
 
     <A-k>   Move current line/selection up
     <A-j>   Move current line/selection down
+    <A-h>   Move current character/selection left
+    <A-l>   Move current character/selection right
 
 The mappings can be prefixed with a count, e.g. `5<A-k>` will move the selection
 up by 5 lines.
 
 See this short demo for a first impression:
 
-![vim-move demo](http://i.imgur.com/RMv8KsJ.gif)
+![vim-vertical-move demo](http://i.imgur.com/RMv8KsJ.gif)
 
+![vim-horizontal-move_demo](https://i.imgur.com/zKWEecp.gif)
 
 ## Installation
 
@@ -42,6 +46,8 @@ which will create the following key bindings:
 
     <C-k>   Move current line/selections up
     <C-j>   Move current line/selections down
+
+And so on...
 
 ## License
 

--- a/doc/move.txt
+++ b/doc/move.txt
@@ -38,10 +38,15 @@ acts as +Esc").
 All mappings can be prefixed with a {count} and will move {count} steps
 instead of one.
 
-By default the plugin indents the buffer after every move operation. Can be
-disabled with >
+By default the plugin indents the buffer after every up/down move operation.
+Can be disabled with >
 
     let g:move_auto_indent = 0
+
+By default the left/right move operations can move text beyond the limit of
+the line. Can be disabled with >
+
+    let g:move_past_end_of_line = 0
 
 -------------------------------------------------------------------------------
 2.1 <Plug>MoveBlockDown
@@ -58,42 +63,70 @@ Move selected block up by one line.
 Default: vmap <A-k> <Plug>MoveBlockUp
 
 -------------------------------------------------------------------------------
-2.3 <Plug>MoveLineDown
+2.3 <Plug>MoveBlockLeft
+
+Move selected block left by one column.
+
+Default: vmap <A-h> <Plug>MoveBlockLeft
+
+-------------------------------------------------------------------------------
+2.4 <Plug>MoveCharRight
+
+Move current bloc right by one column.
+
+Default: nmap <A-l> <Plug>MoveBlockLeft
+
+-------------------------------------------------------------------------------
+2.5 <Plug>MoveLineDown
 
 Move current line down by one.
 
 Default: nmap <A-j> <Plug>MoveLineDown
 
 -------------------------------------------------------------------------------
-2.4 <Plug>MoveLineUp
+2.6 <Plug>MoveLineUp
 
 Move current line up by one.
 
 Default: nmap <A-k> <Plug>MoveLineUp
 
 -------------------------------------------------------------------------------
-2.5 <Plug>MoveBlockHalfPageDown
+2.7 <Plug>MoveCharLeft
+
+Move current line up by one.
+
+Default: nmap <A-h> <Plug>MoveCharLeft
+
+-------------------------------------------------------------------------------
+2.8 <Plug>MoveCharRight
+
+Move current line up by one.
+
+Default: nmap <A-l> <Plug>MoveCharRight
+
+-------------------------------------------------------------------------------
+2.9 <Plug>MoveBlockHalfPageDown
 
 Move selected block down by half a page size.
 
 Default: not mapped
 
 -------------------------------------------------------------------------------
-2.6 <Plug>MoveBlockHalfPageUp
+2.10 <Plug>MoveBlockHalfPageUp
 
 Move selected block up by half a page size.
 
 Default: not mapped
 
 -------------------------------------------------------------------------------
-2.7 <Plug>MoveLineHalfPageDown
+2.11 <Plug>MoveLineHalfPageDown
 
 Move current line down by half a page size.
 
 Default: not mapped
 
 -------------------------------------------------------------------------------
-2.7 <Plug>MoveLineHalfPageUp
+2.12 <Plug>MoveLineHalfPageUp
 
 Move current line up by half a page size.
 
@@ -107,6 +140,11 @@ license.
 
 ===============================================================================
 3. Changelog                                                   *move-changelog*
+
+v1.4
+    * Not yet released
+    * New functionality for moving horizontally
+    * Add g:move_past_end_of_line to control the move to the right.
 
 v1.3
     * Released on 03/18/14

--- a/plugin/move.vim
+++ b/plugin/move.vim
@@ -4,11 +4,11 @@
 " Author: Matthias Vogelgesang <github.com/matze>
 " =============================================================================
 
-if exists('loaded_move') || &cp
+if exists('g:loaded_move') || &compatible
     finish
 endif
 
-let loaded_move = 1
+let g:loaded_move = 1
 
 if !exists('g:move_map_keys')
     let g:move_map_keys = 1
@@ -22,23 +22,27 @@ if !exists('g:move_auto_indent')
     let g:move_auto_indent = 1
 endif
 
+if !exists('g:move_past_end_of_line')
+    let g:move_past_end_of_line = 1
+endif
+
 function! s:ResetCursor()
     normal! gv=gv^
 endfunction
 
 function! s:MoveBlockDown(start, end, count)
-    let next_line = a:end + a:count
+    let l:next_line = a:end + a:count
 
     if v:count > 0
-        let next_line = next_line + v:count - 1
+        let l:next_line = l:next_line + v:count - 1
     endif
 
-    if next_line > line('$')
+    if l:next_line > line('$')
         call s:ResetCursor()
         return
     endif
 
-    execute "silent" a:start "," a:end "m " next_line
+    execute 'silent' a:start ',' a:end 'move ' l:next_line
     if (g:move_auto_indent == 1)
         call s:ResetCursor()
     else
@@ -47,18 +51,18 @@ function! s:MoveBlockDown(start, end, count)
 endfunction
 
 function! s:MoveBlockUp(start, end, count)
-    let prev_line = a:start - a:count - 1
+    let l:prev_line = a:start - a:count - 1
 
     if v:count > 0
-        let prev_line = prev_line - v:count + 1
+        let l:prev_line = l:prev_line - v:count + 1
     endif
 
-    if prev_line < 0
+    if l:prev_line < 0
         call s:ResetCursor()
         return
     endif
 
-    execute "silent" a:start "," a:end "m " prev_line
+    execute 'silent' a:start ',' a:end 'move ' l:prev_line
     if (g:move_auto_indent == 1)
         call s:ResetCursor()
     else
@@ -66,22 +70,76 @@ function! s:MoveBlockUp(start, end, count)
     endif
 endfunction
 
-function! s:MoveLineUp(count) range
-    let distance = a:count + 1
-
-    if v:count > 0
-        let distance = distance + v:count - 1
+function! s:MoveBlockLeft() range
+    if visualmode() ==# "\<C-v>"
+        echomsg 'MoveBlockLeft can only be used in visual block'
     endif
 
-    if (line('.') - distance) < 0
-        execute 'silent m 0'
+    let l:distance = v:count ? v:count : 1
+
+    let l:min_col = min([col("'<"), col("'>")])
+
+    let [l:old_virtualedit, &virtualedit] = [&virtualedit, 'onemore']
+    if l:min_col - l:distance <= 1
+        execute "silent normal! gvd0P`[\<C-v>`]"
+    else
+        execute 'silent normal! gvd' . l:distance . "hP`[\<C-v>`]"
+    endif
+
+    let &virtualedit = l:old_virtualedit
+endfunction
+
+function! s:MoveBlockRight() range
+    if visualmode() ==# "\<C-v>"
+        echomsg 'MoveBlockLeft can only be used in visual block'
+    endif
+
+    let l:distance = v:count ? v:count : 1
+
+    let l:lens = map(getline(a:firstline, a:lastline), 'len(v:val)')
+    let [l:shorter_line_len, l:longer_line_len] = [min(l:lens), max(l:lens)]
+
+    let l:are_same_lines = col("'<") == col("'>")
+    let l:max_col        = max([col("'<"), col("'>")])
+
+    if !g:move_past_end_of_line && (l:max_col + l:distance >= l:shorter_line_len)
+        let l:distance = l:shorter_line_len - l:max_col
+
+        if l:distance == 0
+            silent normal! gv
+            return
+        endif
+    endif
+
+    let [l:old_virtualedit, &virtualedit] = [&virtualedit, 'all']
+    execute 'silent normal! gvd' . l:distance . "lP`[\<C-v>`]"
+
+    " Very strange things happen with 'virtualedit' set to all. One of the is that
+    " the selection loses one column at the left at reselection.
+    " The next line fixes it
+    if !l:are_same_lines && (l:max_col + l:distance < l:longer_line_len)
+        normal! oho
+    endif
+
+   let &virtualedit = l:old_virtualedit
+endfunction
+
+function! s:MoveLineUp(count) range
+    let l:distance = a:count + 1
+
+    if v:count > 0
+        let l:distance = l:distance + v:count - 1
+    endif
+
+    if (line('.') - l:distance) < 0
+        execute 'silent move 0'
         if (g:move_auto_indent == 1)
             normal! ==
         endif
         return
     endif
 
-    execute 'silent m-' . distance
+    execute 'silent m-' . l:distance
 
     if (g:move_auto_indent == 1)
         normal! ==
@@ -89,24 +147,52 @@ function! s:MoveLineUp(count) range
 endfunction
 
 function! s:MoveLineDown(count) range
-    let distance = a:count
+    let l:distance = a:count
 
     if v:count > 0
-        let distance = distance + v:count - 1
+        let l:distance = l:distance + v:count - 1
     endif
 
-    if (line('.') + distance) > line('$')
-        execute 'silent m $'
+    if (line('.') + l:distance) > line('$')
+        silent move $
         if (g:move_auto_indent == 1)
             normal! ==
         endif
         return
     endif
 
-    execute 'silent m+' . distance
+    execute 'silent m+' . l:distance
     if (g:move_auto_indent == 1)
         normal! ==
     endif
+endfunction
+
+" Using range here fucks the col() function (because col() always returns 1 in
+" range functions), so use normal function and clear the range with <C-u> later
+function! s:MoveCharLeft()
+    let l:distance = v:count ? v:count : 1
+
+    if (col('.') - l:distance <= 0)
+        silent normal! x0P
+        return
+    endif
+
+    execute 'silent normal! x' . l:distance . 'hP'
+endfunction
+
+function! s:MoveCharRight()
+    let l:distance = v:count ? v:count : 1
+
+    if !g:move_past_end_of_line && (col('.') + l:distance >= col('$') - 1)
+        silent normal! x$p
+        return
+    endif
+
+    let [l:old_virtualedit, &virtualedit] = [&virtualedit, 'all']
+
+    execute 'silent normal! x' . l:distance . 'lP'
+
+    let &virtualedit = l:old_virtualedit
 endfunction
 
 function! s:MoveBlockOneLineUp() range
@@ -118,23 +204,23 @@ function! s:MoveBlockOneLineDown() range
 endfunction
 
 function! s:MoveBlockHalfPageUp() range
-    let distance = winheight('.') / 2
-    call s:MoveBlockUp(a:firstline, a:lastline, distance)
+    let l:distance = winheight('.') / 2
+    call s:MoveBlockUp(a:firstline, a:lastline, l:distance)
 endfunction
 
 function! s:MoveBlockHalfPageDown() range
-    let distance = winheight('.') / 2
-    call s:MoveBlockDown(a:firstline, a:lastline, distance)
+    let l:distance = winheight('.') / 2
+    call s:MoveBlockDown(a:firstline, a:lastline, l:distance)
 endfunction
 
 function! s:MoveLineHalfPageUp() range
-    let distance = winheight('.') / 2
-    call s:MoveLineUp(distance)
+    let l:distance = winheight('.') / 2
+    call s:MoveLineUp(l:distance)
 endfunction
 
 function! s:MoveLineHalfPageDown() range
-    let distance = winheight('.') / 2
-    call s:MoveLineDown(distance)
+    let l:distance = winheight('.') / 2
+    call s:MoveLineDown(l:distance)
 endfunction
 
 function! s:MoveKey(key)
@@ -146,16 +232,25 @@ vnoremap <silent> <Plug>MoveBlockDown           :call <SID>MoveBlockOneLineDown(
 vnoremap <silent> <Plug>MoveBlockUp             :call <SID>MoveBlockOneLineUp()<CR>
 vnoremap <silent> <Plug>MoveBlockHalfPageDown   :call <SID>MoveBlockHalfPageDown()<CR>
 vnoremap <silent> <Plug>MoveBlockHalfPageUp     :call <SID>MoveBlockHalfPageUp()<CR>
+vnoremap <silent> <Plug>MoveBlockLeft           :call <SID>MoveBlockLeft()<CR>
+vnoremap <silent> <Plug>MoveBlockRight          :call <SID>MoveBlockRight()<CR>
 
 nnoremap <silent> <Plug>MoveLineDown            :call <SID>MoveLineDown(1)<CR>
 nnoremap <silent> <Plug>MoveLineUp              :call <SID>MoveLineUp(1)<CR>
 nnoremap <silent> <Plug>MoveLineHalfPageDown    :call <SID>MoveLineHalfPageDown()<CR>
 nnoremap <silent> <Plug>MoveLineHalfPageUp      :call <SID>MoveLineHalfPageUp()<CR>
+nnoremap <silent> <Plug>MoveCharLeft            :<C-u>call <SID>MoveCharLeft()<CR>
+nnoremap <silent> <Plug>MoveCharRight           :<C-u>call <SID>MoveCharRight()<CR>
 
 
 if g:move_map_keys
     execute 'vmap' s:MoveKey('j') '<Plug>MoveBlockDown'
     execute 'vmap' s:MoveKey('k') '<Plug>MoveBlockUp'
+    execute 'vmap' s:MoveKey('h') '<Plug>MoveBlockLeft'
+    execute 'vmap' s:MoveKey('l') '<Plug>MoveBlockRight'
+
     execute 'nmap' s:MoveKey('j') '<Plug>MoveLineDown'
     execute 'nmap' s:MoveKey('k') '<Plug>MoveLineUp'
+    execute 'nmap' s:MoveKey('h') '<Plug>MoveCharLeft'
+    execute 'nmap' s:MoveKey('l') '<Plug>MoveCharRight'
 endif


### PR DESCRIPTION
* Four new functions to move text left and right.
* New configuration variable: g:move_past_end_of_line to control the
  behavior of the previous functions.
* Specify scope of all variables
* Delete one unnecessary use of execute