### PR TITLE
Visual downwards move with big count goes to end of line and new configuration options

### DIFF
--- a/doc/move.txt
+++ b/doc/move.txt
@@ -141,6 +141,11 @@ license.
 ===============================================================================
 3. Changelog                                                   *move-changelog*
 
+v1.4.1
+    * Bug corrections from 1.4
+    * If vertical movement receives a count past end of file, it moves to the
+      end instead of staying in place.
+
 v1.4
     * Released on 08/19/18
     * New functionality for moving horizontally

--- a/doc/move.txt
+++ b/doc/move.txt
@@ -20,9 +20,30 @@ wrapping the :move command.
 ===============================================================================
 2. Mappings                                                     *move-mappings*
 
-To enable custom key maps you must disable the automatic key maps with >
+To enable/disable automatic key maps you can define the variable
+g:move_map_keys in to 1 or 0 respectively. IE, if you want to define your own
+key mappings you would put in your vimrc: >
 
     let g:move_map_keys = 0
+
+The default value of g:move_map_keys is 1 so all mappings are usually defined.
+
+The automatic key maps also can be enabled/disabled by parts defining
+g:move_map_keys as a dictionary instad of an integer. This can be
+done through the entries 'vertical' and 'horizontal' each of which should be
+also a dictionary with the integer (boolean) entries 'normal' and 'visual'.
+With that in mind, if you want to have the vertical mappings only enabled in
+visual mode but the horizontal mappings to be enabled in both modes you can
+define g:move_map_keys as: >
+
+    let g:move_map_keys = {}
+    let g:move_map_keys.vertical = {'normal': 0, 'visual': 1}
+    let g:move_map_keys.horizontal = {'normal': 1, 'visual': 1}
+
+Or, as the default values of all entries are also 1, it can be simply
+written as: >
+
+    let g:move_map_keys = {'vertical': {'normal': 0}}
 
 The plugin provide finger-friendly mappings to move text around by using <jk>
 keys. You can specify the key modifier that is used in key bindings with >
@@ -145,6 +166,7 @@ v1.4.1
     * Bug corrections from 1.4
     * If vertical movement receives a count past end of file, it moves to the
       end instead of staying in place.
+    * The standard mappings can be enabled by parts through a dictionary.
 
 v1.4
     * Released on 08/19/18

--- a/plugin/move.vim
+++ b/plugin/move.vim
@@ -10,7 +10,7 @@ if exists('g:loaded_move') || &compatible
 endif
 let g:loaded_move = 1
 
-" =====[ Configuration Variables ]=====
+" =====[ Configuration Variables ]================
 function! s:SetDefaultValue(var, val)
     if !exists(a:var)
         execute 'let' a:var '=' string(a:val)
@@ -23,13 +23,22 @@ call s:SetDefaultValue('g:move_auto_indent', 1)
 call s:SetDefaultValue('g:move_map_keys', 1)
 call s:SetDefaultValue('g:move_past_end_of_line', 1)
 
-" =====[ Script local variables ]=====
+if type(g:move_map_keys) == type({})
+    call s:SetDefaultValue('g:move_map_keys.vertical', {})
+    call s:SetDefaultValue('g:move_map_keys.vertical.normal', 1)
+    call s:SetDefaultValue('g:move_map_keys.vertical.visual', 1)
+    call s:SetDefaultValue('g:move_map_keys.horizontal', {})
+    call s:SetDefaultValue('g:move_map_keys.horizontal.normal', 1)
+    call s:SetDefaultValue('g:move_map_keys.horizontal.visual', 1)
+endif
+
+" =====[ Script local variables ]=================
 let s:command_blockwise_selection = "\<C-v>"
 " After deleting and pasting "gv" would select the old position but the
 " following command selects the position of the pasted text
 let s:command_select_after_P = '`[' . s:command_blockwise_selection . '`]'
 
-" =====[ Utility functions ]=====
+" =====[ Utility functions ]======================
 function! s:ResetCursor()
     normal! gv=gv^
 endfunction
@@ -48,7 +57,7 @@ function! s:MoveKey(key)
     return '<' . g:move_key_modifier . '-' . a:key . '>'
 endfunction
 
-" =====[ Functionality ]=====
+" =====[ Functionality ]==========================
 function! s:MoveBlockDown(start, end, num)
     let l:next_line = a:end + a:num + max([0, v:count - 1])
     let l:next_line = min([line('$'), l:next_line])
@@ -79,6 +88,8 @@ function! s:MoveBlockLeft() range
     let l:distance = v:count ? v:count : 1
     let l:min_col  = min([col("'<"), col("'>")])
 
+    " Having 'virtualenv' set to 'onemore' fixes problem of one more movement
+    " that needed when moving block from end of line to the left
     let [l:old_virtualedit, &virtualedit] = [&virtualedit, 'onemore']
 
     let l:move_command = 'silent normal! gvd'
@@ -190,7 +201,7 @@ function! s:MoveBlockNumUp(num) range
     call s:MoveBlockUp(a:firstline, a:lastline, a:num)
 endfunction
 
-" =====[ API ]=====
+" =====[ API ]===================================
 vnoremap <silent> <Plug>MoveBlockDown           :call <SID>MoveBlockNumDown(1)<CR>
 vnoremap <silent> <Plug>MoveBlockUp             :call <SID>MoveBlockNumUp(1)<CR>
 vnoremap <silent> <Plug>MoveBlockHalfPageDown   :call <SID>MoveBlockNumDown(s:HalfWin())<CR>
@@ -205,14 +216,35 @@ nnoremap <silent> <Plug>MoveLineHalfPageUp      :<C-u>call <SID>MoveLineUp(s:Hal
 nnoremap <silent> <Plug>MoveCharLeft            :<C-u>call <SID>MoveCharLeft()<CR>
 nnoremap <silent> <Plug>MoveCharRight           :<C-u>call <SID>MoveCharRight()<CR>
 
-if g:move_map_keys
-    execute 'vmap' s:MoveKey('j') '<Plug>MoveBlockDown'
-    execute 'vmap' s:MoveKey('k') '<Plug>MoveBlockUp'
-    execute 'vmap' s:MoveKey('h') '<Plug>MoveBlockLeft'
-    execute 'vmap' s:MoveKey('l') '<Plug>MoveBlockRight'
+function! s:UserWantMap(movement, mode)
+    " In vim 8, v:t_number can be used instead of type(0) and v:t_dict instead
+    " of type({}), but at the cost of losing compatibility with previous
+    " versions
+    if type(g:move_map_keys) == type(0)
+        return g:move_map_keys != 0
+    endif
 
+    if type(g:move_map_keys) == type({})
+        return g:move_map_keys[a:movement][a:mode] != 0
+    endif
+endfunction
+
+if s:UserWantMap('vertical', 'visual')
+    execute 'xmap' s:MoveKey('j') '<Plug>MoveBlockDown'
+    execute 'xmap' s:MoveKey('k') '<Plug>MoveBlockUp'
+endif
+
+if s:UserWantMap('horizontal', 'visual')
+    execute 'xmap' s:MoveKey('h') '<Plug>MoveBlockLeft'
+    execute 'xmap' s:MoveKey('l') '<Plug>MoveBlockRight'
+endif
+
+if s:UserWantMap('vertical', 'normal')
     execute 'nmap' s:MoveKey('j') '<Plug>MoveLineDown'
     execute 'nmap' s:MoveKey('k') '<Plug>MoveLineUp'
+endif
+
+if s:UserWantMap('horizontal', 'normal')
     execute 'nmap' s:MoveKey('h') '<Plug>MoveCharLeft'
     execute 'nmap' s:MoveKey('l') '<Plug>MoveCharRight'
 endif


### PR DESCRIPTION
The lose of one column issue with 'virtualedit' wasn't related with the
longest line as previously thought, but with the first line (smallest
one) of selection, so changing it fixes now for real (hopefully) the bug
of losing one column after moving.

Using "range" in functions that didn't used visual selection was a
problem when (a:firstline + count) greater than the last line so that
range was deleted and replaced with <C-u> at the function calls.

The name 'are_same_line' was really referring to a column, so it was
renamed after 'are_same_cols'

Create function to initialize configurations variables to its defaults.

The variable g:move_map_key can also be a dictionary to permit
enabling/disabling of parts of the default mappings using the entries
'vertical' and 'horizontal' and its subentries 'normal' and 'visual'.