### PR TITLE
Fix double jump calling MoveCharLeft on last character

### DIFF
--- a/plugin/move.vim
+++ b/plugin/move.vim
@@ -209,20 +209,23 @@ endfunction
 " Using range here fucks the col() function (because col() always returns 1 in
 " range functions), so use normal function and clear the range with <C-u> later
 function! s:MoveCharLeft()
-    if !&modifiable || virtcol("$") == 1
+    if !&modifiable || virtcol("$") == 1 || virtcol(".") == 1
         return
     endif
 
     let l:distance = v:count ? v:count : 1
 
     call s:SaveDefaultRegister()
+
     if (virtcol('.') - l:distance <= 0)
         silent normal! x0P
-        return
+    else
+        let [l:old_virtualedit, &virtualedit] = [&virtualedit, 'onemore']
+        execute 'silent normal! x' . l:distance . 'hP'
+        let &virtualedit = l:old_virtualedit
     endif
 
     call s:RestoreDefaultRegister()
-    execute 'silent normal! x' . l:distance . 'hP'
 endfunction
 
 function! s:MoveCharRight()
@@ -231,19 +234,17 @@ function! s:MoveCharRight()
     endif
 
     let l:distance = v:count ? v:count : 1
+    call s:SaveDefaultRegister()
 
     if !g:move_past_end_of_line && (virtcol('.') + l:distance >= virtcol('$') - 1)
         silent normal! x$p
-        return
+    else
+        let [l:old_virtualedit, &virtualedit] = [&virtualedit, 'all']
+        execute 'silent normal! x' . l:distance . 'lP'
+        let &virtualedit = l:old_virtualedit
     endif
 
-    let [l:old_virtualedit, &virtualedit] = [&virtualedit, 'all']
-    call s:SaveDefaultRegister()
-
-    execute 'silent normal! x' . l:distance . 'lP'
-
     call s:RestoreDefaultRegister()
-    let &virtualedit = l:old_virtualedit
 endfunction
 
 function! s:MoveBlockOneLineUp() range


### PR DESCRIPTION
### Changes
* Use virtual edit in `onemore` mode to prevent cutting the last character of the line causing the cursor to shift left.
* Re-arrange branches in `MoveCharLeft` and `MoveCharRight` to ensure that buffer is always saved and restored before/after a command is invoked.

### Patch
![last_char_fix](https://user-images.githubusercontent.com/3442461/62869940-bf3ea600-bd53-11e9-94a3-e001857c8c73.gif)

### Without patch
![last_char_master](https://user-images.githubusercontent.com/3442461/62869965-cc5b9500-bd53-11e9-888d-f414f2f00ba3.gif)

