### PR TITLE
Handle re-selection consistently for horizontal block moves

### DIFF
--- a/plugin/move.vim
+++ b/plugin/move.vim
@@ -110,7 +110,22 @@ function! s:MoveBlockLeft() range
     let [l:old_virtualedit, &virtualedit] = [&virtualedit, 'onemore']
     call s:SaveDefaultRegister()
 
+    " save previous cursor position
+    silent normal! gv
+    let l:row_pos = getcurpos()[1]
+    let l:is_rhs = virtcol(".") == max([virtcol("'<"), virtcol("'>")])
+
     execute 'silent normal! gvd' . l:distance . "hP`[\<C-v>`]"
+
+    " restore previous cursor position
+    if getcurpos()[1] != l:row_pos
+        silent normal! o
+        if l:is_rhs
+           silent normal! O
+        endif
+    elseif !l:is_rhs
+        silent normal! O
+    endif
 
     call s:RestoreDefaultRegister()
     let &virtualedit = l:old_virtualedit
@@ -152,12 +167,27 @@ function! s:MoveBlockRight() range
     let [l:old_virtualedit, &virtualedit] = [&virtualedit, 'all']
     call s:SaveDefaultRegister()
 
+    " save previous cursor position
+    silent normal! gv
+    let l:row_pos = getcurpos()[1]
+    let l:is_rhs = virtcol(".") == l:max_col
+
     execute 'silent normal! gvd' . l:distance . "l"
     " P behaves inconsistently in virtualedit 'all' mode; sometimes the cursor
     " moves one right after pasting, other times it doesn't. This makes it
     " difficult to rely on `[ to determine the start of the shifted selection.
     let l:new_start_pos = virtcol(".")
     execute 'silent normal! P' . l:new_start_pos . "|\<C-v>`]"
+
+    " restore previous cursor position
+    if getcurpos()[1] != l:row_pos
+        silent normal! o
+        if l:is_rhs
+           silent normal! O
+        endif
+    elseif !l:is_rhs
+        silent normal! O
+    endif
 
     call s:RestoreDefaultRegister()
     let &virtualedit = l:old_virtualedit


### PR DESCRIPTION
#### Changes
* Removes the reliance on `` `[`` to go the start of the shifted selection to simplify the re-selection logic.
* Preserve cursor position on `MoveBlockLeft` and `MoveBlockRight`

### Info
I realized that PR #34 didn't address the root cause of the problem it's trying to fix. 

The root cause is that `P` in `virtualedit=all` mode behaves inconsistently; the cursor sometimes moves one column right after pasting, other times it doesn't. This makes it difficult to rely on `` `[`` to determine the start of the shifted selection.

PR #34 attempted to work around the inconsistencies but couldn't handle all cases:

![34f](https://user-images.githubusercontent.com/3442461/63214713-c4866100-c156-11e9-8edf-e4b09526a350.gif)

With this patch:

![34ff](https://user-images.githubusercontent.com/3442461/63214773-8a698f00-c157-11e9-9ae9-0446632a9f49.gif)
