### PR TITLE
Make vertical moves with large counts move to the first or last line.

### DIFF
--- a/plugin/move.vim
+++ b/plugin/move.vim
@@ -180,7 +180,7 @@ function! s:MoveBlockRight(distance) range
     let &virtualedit = l:old_virtualedit
 endfunction
 
-function! s:MoveLineUp(distance) range
+function! s:MoveLineUp(distance)
     if !&modifiable || line('.') == 1
         return
     endif
@@ -205,7 +205,7 @@ function! s:MoveLineUp(distance) range
     execute 'silent normal!' . max([1, (virtcol('.') + l:relative_cursor_col - 1)]) . '|'
 endfunction
 
-function! s:MoveLineDown(distance) range
+function! s:MoveLineDown(distance)
     if !&modifiable || line('.') ==  line('$')
         return
     endif
@@ -229,8 +229,6 @@ function! s:MoveLineDown(distance) range
     execute 'silent normal!' . max([1, (virtcol('.') + l:relative_cursor_col - 1)]) . '|'
 endfunction
 
-" Using range here fucks the col() function (because col() always returns 1 in
-" range functions), so use normal function and clear the range with <C-u> later
 function! s:MoveCharLeft(distance)
     if !&modifiable || virtcol("$") == 1 || virtcol(".") == 1
         return
@@ -285,12 +283,12 @@ function! s:MoveBlockHalfPageDown(count) range
     call s:MoveBlockDown(a:firstline, a:lastline, l:distance)
 endfunction
 
-function! s:MoveLineHalfPageUp(count) range
+function! s:MoveLineHalfPageUp(count)
     let l:distance = a:count * (winheight('.') / 2)
     call s:MoveLineUp(l:distance)
 endfunction
 
-function! s:MoveLineHalfPageDown(count) range
+function! s:MoveLineHalfPageDown(count)
     let l:distance = a:count * (winheight('.') / 2)
     call s:MoveLineDown(l:distance)
 endfunction
@@ -307,12 +305,16 @@ vnoremap <silent> <Plug>MoveBlockHalfPageUp     :call <SID>MoveBlockHalfPageUp(v
 vnoremap <silent> <Plug>MoveBlockLeft           :call <SID>MoveBlockLeft(v:count1)<CR>
 vnoremap <silent> <Plug>MoveBlockRight          :call <SID>MoveBlockRight(v:count1)<CR>
 
-nnoremap <silent> <Plug>MoveLineDown            :call <SID>MoveLineDown(v:count1)<CR>
-nnoremap <silent> <Plug>MoveLineUp              :call <SID>MoveLineUp(v:count1)<CR>
-nnoremap <silent> <Plug>MoveLineHalfPageDown    :call <SID>MoveLineHalfPageDown(v:count1)<CR>
-nnoremap <silent> <Plug>MoveLineHalfPageUp      :call <SID>MoveLineHalfPageUp(v:count1)<CR>
-nnoremap <silent> <Plug>MoveCharLeft            :<C-u>call <SID>MoveCharLeft(v:count1)<CR>
-nnoremap <silent> <Plug>MoveCharRight           :<C-u>call <SID>MoveCharRight(v:count1)<CR>
+" We can't use functions defined with the 'range' attribute for moving lines
+" or characters. In the case of lines, it causes vim to complain with E16
+" (Invalid adress) if we try to move out of bounds. In the case of characters,
+" it messes up the result of calling col().
+nnoremap <silent> <Plug>MoveLineDown            :<C-u> call <SID>MoveLineDown(v:count1)<CR>
+nnoremap <silent> <Plug>MoveLineUp              :<C-u> call <SID>MoveLineUp(v:count1)<CR>
+nnoremap <silent> <Plug>MoveLineHalfPageDown    :<C-u> call <SID>MoveLineHalfPageDown(v:count1)<CR>
+nnoremap <silent> <Plug>MoveLineHalfPageUp      :<C-u> call <SID>MoveLineHalfPageUp(v:count1)<CR>
+nnoremap <silent> <Plug>MoveCharLeft            :<C-u> call <SID>MoveCharLeft(v:count1)<CR>
+nnoremap <silent> <Plug>MoveCharRight           :<C-u> call <SID>MoveCharRight(v:count1)<CR>
 
 
 if g:move_map_keys

--- a/plugin/move.vim
+++ b/plugin/move.vim
@@ -50,7 +50,7 @@ function! s:MoveBlockDown(start, end, distance)
         return
     endif
 
-    let l:next_line = a:end + a:distance
+    let l:next_line = min([a:end + a:distance, line('$')])
 
     if l:next_line > line('$')
         call s:ResetCursor()
@@ -70,14 +70,14 @@ function! s:MoveBlockUp(start, end, distance)
         return
     endif
 
-    let l:prev_line = a:start - a:distance - 1
+    let l:prev_line = max([a:start - a:distance, 1])
 
     if l:prev_line < 0
         call s:ResetCursor()
         return
     endif
 
-    execute 'silent' a:start ',' a:end 'move ' l:prev_line
+    execute 'silent' a:start ',' a:end 'move ' (l:prev_line - 1)
     if (g:move_auto_indent == 1)
         call s:ResetCursor()
     else

--- a/plugin/move.vim
+++ b/plugin/move.vim
@@ -50,7 +50,7 @@ function! s:MoveBlockDown(start, end, nlines)
         return
     endif
 
-    let l:distance = a:nlines * (v:count ? v:count : 1)
+    let l:distance = a:nlines * v:count1
     let l:next_line = a:end + l:distance
 
     if l:next_line > line('$')
@@ -71,7 +71,7 @@ function! s:MoveBlockUp(start, end, nlines)
         return
     endif
 
-    let l:distance = a:nlines * (v:count ? v:count : 1)
+    let l:distance = a:nlines * v:count1
     let l:prev_line = a:start - l:distance - 1
 
     if l:prev_line < 0
@@ -89,7 +89,7 @@ endfunction
 
 function! s:MoveBlockLeft() range
     let l:min_col = min([virtcol("'<"), virtcol("'>")])
-    let l:distance = min([l:min_col - 1, v:count ? v:count : 1])
+    let l:distance = min([l:min_col - 1, v:count1])
 
     if !&modifiable || virtcol("$") == 1 || l:distance <= 0 || visualmode() ==# "V"
         normal! gv
@@ -128,7 +128,7 @@ endfunction
 
 function! s:MoveBlockRight() range
     let l:max_col = max([virtcol("'<"), virtcol("'>")])
-    let l:distance = v:count ? v:count : 1
+    let l:distance = v:count1
 
     if !g:move_past_end_of_line
         let l:shorter_line_len = min(map(getline(a:firstline, a:lastline), 'strwidth(v:val)'))
@@ -187,7 +187,7 @@ function! s:MoveLineUp(nlines) range
         return
     endif
 
-    let l:distance = a:nlines * (v:count ? v:count : 1)
+    let l:distance = a:nlines * v:count1
     let l:relative_cursor_col = s:GetRelativeCursorVirtCol()
 
     if (line('.') - l:distance) < 0
@@ -213,7 +213,7 @@ function! s:MoveLineDown(nlines) range
         return
     endif
 
-    let l:distance = a:nlines * (v:count ? v:count : 1)
+    let l:distance = a:nlines * v:count1
     let l:relative_cursor_col = s:GetRelativeCursorVirtCol()
 
     if (line('.') + l:distance) > line('$')
@@ -240,7 +240,7 @@ function! s:MoveCharLeft()
         return
     endif
 
-    let l:distance = v:count ? v:count : 1
+    let l:distance = v:count1
 
     call s:SaveDefaultRegister()
 
@@ -260,7 +260,7 @@ function! s:MoveCharRight()
         return
     endif
 
-    let l:distance = v:count ? v:count : 1
+    let l:distance = v:count1
     call s:SaveDefaultRegister()
 
     if !g:move_past_end_of_line && (virtcol('.') + l:distance >= virtcol('$') - 1)


### PR DESCRIPTION
While working on my last PR I noticed that sometimes we would get an error if we tried to make a large vertical move, when the count was large enough to send the lines "out of bounds". 

When moving a lines, if it was only slightly out of bounds (1 too much) then it would move the line to the end of the file. The main situation where this happens is if we move the last line down by one -- it stays in the same place without giving an error. It also did not give an error if you tried to move the penultimate line down by two -- it would move it down by one, so it became the last line in the file. However, if you try to move the last line down by 2+ or the penultimate line by 3+ it would give an error E16: Invalid Range.

Moving blocks vertically had a similar problem. If the block was at the end of the file and we tried to move down by one it would also do nothing. But if we tried do move the penultimate line by 2 or by 3+ it would not move it at all.

This commit updates the behavior to be more consistent. Large vertical moves now move the line/block to the first or last line of the file, without throwing any errors.