### PR TITLE
Cleaning up the MoveLeft and MoveRight functions

### DIFF
--- a/plugin/move.vim
+++ b/plugin/move.vim
@@ -51,7 +51,7 @@ function s:MoveBlockVertically(distance)
     else
         let l:after = min([line('$'), l:last  + a:distance])
     endif
-    execute 'silent' l:first ',' l:last 'move ' l:after
+    execute l:first ',' l:last 'move ' l:after
 
     if g:move_auto_indent
         normal! gv=
@@ -175,7 +175,7 @@ function! s:MoveLineVertically(distance)
     " Remember the current cursor position. When we move or reindent a line
     " Vim will move the cursor to the first non-blank character.
     let l:old_cursor_col = virtcol('.')
-    silent normal! ^
+    normal! ^
     let l:old_indent     = virtcol('.')
 
     if a:distance <= 0
@@ -183,16 +183,16 @@ function! s:MoveLineVertically(distance)
     else
         let l:after = min([line('$'), line('.') + a:distance])
     endif
-    execute 'silent move' l:after
+    execute 'move' l:after
 
     if g:move_auto_indent
-        silent normal! ==
+        normal! ==
     endif
 
     " Restore the cursor column, taking indentation changes into account.
     let l:new_indent = virtcol('.')
     let l:new_cursor_col = max([1, l:old_cursor_col - l:old_indent + l:new_indent])
-    execute 'silent normal!'  l:new_cursor_col . '|'
+    execute 'normal!'  (l:new_cursor_col . '|')
 endfunction
 
 "

--- a/plugin/move.vim
+++ b/plugin/move.vim
@@ -82,9 +82,12 @@ function! s:MoveBlockHorizontally(distance)
     let l:before = max([1, l:first + a:distance])
     if a:distance > 0 && !g:move_past_end_of_line
         let l:shortest = min(map(getline("'<", "'>"), 'strwidth(v:val)'))
-        let l:limit    = max([l:first, l:shortest-width+1])
-        let l:before   = min([l:before, l:limit])
-    end
+        if l:last < l:shortest
+            let l:before = min([l:before, l:shortest - width + 1])
+        else
+            let l:before = l:first
+        endif
+    endif
 
     if l:first == l:before
         " Don't add an empty change to the undo stack.

--- a/plugin/move.vim
+++ b/plugin/move.vim
@@ -26,14 +26,6 @@ if !exists('g:move_past_end_of_line')
     let g:move_past_end_of_line = 1
 endif
 
-function! s:SaveDefaultRegister()
-   let s:default_register_value = @"
-endfunction
-
-function! s:RestoreDefaultRegister()
-   let @" = s:default_register_value
-endfunction
-
 "
 " In visual mode, move the selected lines vertically.
 " Moves down if (distance > 0) and up if (distance < 0).
@@ -80,7 +72,7 @@ function! s:MoveBlockLeft(distance) range
     endif
 
     let [l:old_virtualedit, &virtualedit] = [&virtualedit, 'onemore']
-    call s:SaveDefaultRegister()
+    let l:old_default_register = @"
 
     " save previous cursor position
     silent normal! gv
@@ -99,7 +91,7 @@ function! s:MoveBlockLeft(distance) range
         silent normal! O
     endif
 
-    call s:RestoreDefaultRegister()
+    let @" = l:old_default_register
     let &virtualedit = l:old_virtualedit
 endfunction
 
@@ -135,7 +127,7 @@ function! s:MoveBlockRight(distance) range
 
 
     let [l:old_virtualedit, &virtualedit] = [&virtualedit, 'all']
-    call s:SaveDefaultRegister()
+    let l:old_default_register = @"
 
     " save previous cursor position
     silent normal! gv
@@ -159,7 +151,7 @@ function! s:MoveBlockRight(distance) range
         silent normal! O
     endif
 
-    call s:RestoreDefaultRegister()
+    let @" = l:old_default_register
     let &virtualedit = l:old_virtualedit
 endfunction
 
@@ -215,7 +207,7 @@ function! s:MoveCharHorizontally(distance)
         return
     endif
 
-    call s:SaveDefaultRegister()
+    let l:old_default_register = @"
     let [l:old_virtualedit, &virtualedit] = [&virtualedit, 'all']
 
     normal! x
@@ -223,7 +215,7 @@ function! s:MoveCharHorizontally(distance)
     normal! P
 
     let &virtualedit = l:old_virtualedit
-    call s:RestoreDefaultRegister()
+    let @" = l:old_default_register
 
 endfunction
 

--- a/plugin/move.vim
+++ b/plugin/move.vim
@@ -38,17 +38,20 @@ endfunction
 " In visual mode, move the selected lines vertically.
 " Moves down if (distance > 0) and up if (distance < 0).
 "
-function s:MoveBlockVertically(distance) range
+function s:MoveBlockVertically(distance)
     if !&modifiable
         return
     endif
 
+    let l:first = line("'<")
+    let l:last  = line("'>")
+
     if a:distance <= 0
-        let l:after = max([1,         a:firstline + a:distance]) - 1
+        let l:after = max([1,         l:first + a:distance]) - 1
     else
-        let l:after = min([line('$'), a:lastline  + a:distance])
+        let l:after = min([line('$'), l:last  + a:distance])
     endif
-    execute 'silent' a:firstline ',' a:lastline 'move ' l:after
+    execute 'silent' l:first ',' l:last 'move ' l:after
 
     if g:move_auto_indent
         normal! gv=
@@ -243,10 +246,10 @@ function! s:MoveKey(key)
 endfunction
 
 
-vnoremap <silent> <Plug>MoveBlockDown           :call <SID>MoveBlockVertically( v:count1)<CR>
-vnoremap <silent> <Plug>MoveBlockUp             :call <SID>MoveBlockVertically(-v:count1)<CR>
-vnoremap <silent> <Plug>MoveBlockHalfPageDown   :call <SID>MoveBlockVertically( v:count1 * <SID>HalfPageSize())<CR>
-vnoremap <silent> <Plug>MoveBlockHalfPageUp     :call <SID>MoveBlockVertically(-v:count1 * <SID>HalfPageSize())<CR>
+vnoremap <silent> <Plug>MoveBlockDown           :<C-u> call <SID>MoveBlockVertically( v:count1)<CR>
+vnoremap <silent> <Plug>MoveBlockUp             :<C-u> call <SID>MoveBlockVertically(-v:count1)<CR>
+vnoremap <silent> <Plug>MoveBlockHalfPageDown   :<C-u> call <SID>MoveBlockVertically( v:count1 * <SID>HalfPageSize())<CR>
+vnoremap <silent> <Plug>MoveBlockHalfPageUp     :<C-u> call <SID>MoveBlockVertically(-v:count1 * <SID>HalfPageSize())<CR>
 vnoremap <silent> <Plug>MoveBlockLeft           :call <SID>MoveBlockLeft(v:count1)<CR>
 vnoremap <silent> <Plug>MoveBlockRight          :call <SID>MoveBlockRight(v:count1)<CR>
 

--- a/plugin/move.vim
+++ b/plugin/move.vim
@@ -34,6 +34,10 @@ function! s:RestoreDefaultRegister()
    let @" = s:default_register_value
 endfunction
 
+"
+" In visual mode, move the selected lines vertically.
+" Moves down if (distance > 0) and up if (distance < 0).
+"
 function s:MoveBlockVertically(distance) range
     if !&modifiable
         return
@@ -53,6 +57,10 @@ function s:MoveBlockVertically(distance) range
     normal! gv
 endfunction
 
+"
+" In visual mode, move the selected block to the left
+" Switches to visual-block mode first if another visual mode is selected.
+"
 function! s:MoveBlockLeft(distance) range
     let l:min_col = min([virtcol("'<"), virtcol("'>")])
     let l:distance = min([a:distance, l:min_col - 1])
@@ -92,6 +100,10 @@ function! s:MoveBlockLeft(distance) range
     let &virtualedit = l:old_virtualedit
 endfunction
 
+"
+" In visual mode, move the selected block to the right
+" Switches to visual-block mode first if another visual mode is selected.
+"
 function! s:MoveBlockRight(distance) range
     let l:max_col = max([virtcol("'<"), virtcol("'>")])
 
@@ -148,6 +160,10 @@ function! s:MoveBlockRight(distance) range
     let &virtualedit = l:old_virtualedit
 endfunction
 
+"
+" In normal mode, move the current line vertically.
+" Moves down if (distance > 0) and up if (distance < 0).
+"
 function! s:MoveLineVertically(distance)
     if !&modifiable
         return
@@ -176,6 +192,9 @@ function! s:MoveLineVertically(distance)
     execute 'silent normal!'  l:new_cursor_col . '|'
 endfunction
 
+"
+" In normal mode, move the character under the cursor to the left
+"
 function! s:MoveCharLeft(distance)
     if !&modifiable || virtcol("$") == 1 || virtcol(".") == 1
         return
@@ -194,6 +213,9 @@ function! s:MoveCharLeft(distance)
     call s:RestoreDefaultRegister()
 endfunction
 
+"
+" In normal mode, move the character under the cursor to the right
+"
 function! s:MoveCharRight(distance)
     if !&modifiable || virtcol("$") == 1
         return


### PR DESCRIPTION
This PR continues the cleanup effort from #45.

- Add comments
- Consolidate MoveCharRight and MoveCharLeft
- Consolidate MoveBlockRight and MoveBlockLeft
- Stop using  "silent" where we didn't need to
- Stop leaking the value of the default register
- Stop using the finicky functions with the "range" attribute -- use <C-u> for everything.

I think everything is still working but I would appreciate if you could double check, specially the MoveBlockHorizontally. Some of those changes were not trivial and I'm not 100% sure that I was able to test all the corner cases.