### PR TITLE
Simplify the MoveVertically functions even more

### DIFF
--- a/plugin/move.vim
+++ b/plugin/move.vim
@@ -48,7 +48,7 @@ function! s:MoveVertically(first, last, distance)
     " After a :move the '[ and '] marks point to first and last moved line
     " and the cursor is placed at the last line.
     if g:move_auto_indent
-        normal! =g'[ g']
+        normal! g'[=g']
     endif
 
 endfunction

--- a/plugin/move.vim
+++ b/plugin/move.vim
@@ -59,16 +59,16 @@ endfunction
 "
 function! s:MoveLineVertically(distance)
 
-    let l:old_cursor_col = virtcol('.')
+    let l:old_col    = virtcol('.')
     normal! ^
-    let l:old_indent     = virtcol('.')
+    let l:old_indent = virtcol('.')
 
     call s:MoveVertically(line('.'), line('.'), a:distance)
 
     normal! ^
-    let l:new_indent     = virtcol('.')
-    let l:new_cursor_col = max([1, l:old_cursor_col - l:old_indent + l:new_indent])
-    execute 'normal!'  (l:new_cursor_col . '|')
+    let l:new_indent = virtcol('.')
+    let l:new_col    = max([1, l:old_col - l:old_indent + l:new_indent])
+    execute 'normal!'  (l:new_col . '|')
 endfunction
 
 "
@@ -145,7 +145,7 @@ function! s:MoveBlockHorizontally(distance)
     if a:distance > 0 && !g:move_past_end_of_line
         let l:shortest = min(map(getline("'<", "'>"), 'strwidth(v:val)'))
         if l:last < l:shortest
-            let l:before = min([l:before, l:shortest - width + 1])
+            let l:before = min([l:before, l:shortest - l:width + 1])
         else
             let l:before = l:first
         endif

--- a/plugin/move.vim
+++ b/plugin/move.vim
@@ -27,61 +27,59 @@ if !exists('g:move_past_end_of_line')
 endif
 
 "
-" In normal mode, move the current line vertically.
-" Moves down if (distance > 0) and up if (distance < 0).
+" Move and possibly reindent the given lines.
+" Goes down if (distance > 0) and up if (distance < 0).
+" Places the cursor at last moved line.
 "
-function! s:MoveLineVertically(distance)
+function! s:MoveVertically(first, last, distance)
     if !&modifiable
         return
     endif
 
-    " Remember the current cursor position. When we move or reindent a line
-    " Vim will move the cursor to the first non-blank character.
+    " To avoid 'Invalid range' errors we must ensure that the destination
+    " line is valid and that we don't try to move a range into itself.
+    if a:distance <= 0
+        let l:after = max([1,         a:first + a:distance]) - 1
+    else
+        let l:after = min([line('$'), a:last  + a:distance])
+    endif
+    execute a:first ',' a:last 'move ' l:after
+
+    " After a :move the '[ and '] marks point to first and last moved line
+    " and the cursor is placed at the last line.
+    if g:move_auto_indent
+        normal! =g'[ g']
+    endif
+
+endfunction
+
+"
+" In normal mode, move the current line vertically.
+" The cursor stays pointing at the same character as before.
+"
+function! s:MoveLineVertically(distance)
+
     let l:old_cursor_col = virtcol('.')
     normal! ^
     let l:old_indent     = virtcol('.')
 
-    if a:distance <= 0
-        let l:after = max([1,         line('.') + a:distance]) - 1
-    else
-        let l:after = min([line('$'), line('.') + a:distance])
-    endif
-    execute 'move' l:after
+    call s:MoveVertically(line('.'), line('.'), a:distance)
 
-    if g:move_auto_indent
-        normal! ==
-    endif
-
-    " Restore the cursor column, taking indentation changes into account.
-    let l:new_indent = virtcol('.')
+    normal! ^
+    let l:new_indent     = virtcol('.')
     let l:new_cursor_col = max([1, l:old_cursor_col - l:old_indent + l:new_indent])
     execute 'normal!'  (l:new_cursor_col . '|')
 endfunction
 
 "
 " In visual mode, move the selected lines vertically.
-" Moves down if (distance > 0) and up if (distance < 0).
+" Maintains the current selection, albeit not exactly if auto_indent is on.
 "
 function s:MoveBlockVertically(distance)
-    if !&modifiable
-        return
-    endif
 
-    let l:first = line("'<")
-    let l:last  = line("'>")
-
-    if a:distance <= 0
-        let l:after = max([1,         l:first + a:distance]) - 1
-    else
-        let l:after = min([line('$'), l:last  + a:distance])
-    endif
-    execute l:first ',' l:last 'move ' l:after
-
-    if g:move_auto_indent
-        normal! gv=
-    endif
-
+    call s:MoveVertically(line("'<"), line("'>"), a:distance)
     normal! gv
+
 endfunction
 
 "


### PR DESCRIPTION
By taking advantage of '[ and '] we can use the same method to reindent the lines in MoveLineVertically and MoveBlockVertically. This lets us put all the line-moving logic in a single place. I suspect that it might also be possible to do something similar to the MoveHorizontally functions but I haven't figured out exactly how yet.

There is also a small improvement to the behavior of MoveBlockVertically when "nomodifiable" is set. Previously we would end up in normal mode after the function was called and now we stay in visual mode, with the
current selection preserved.