### PR TITLE
More improvements to the MoveHorizontally functions

### DIFF
--- a/plugin/move.vim
+++ b/plugin/move.vim
@@ -87,19 +87,20 @@ endfunction
 " Goes right if (distance > 0) and left if (distance < 0).
 " Returns whether an edit was made.
 "
-function s:MoveHorizontally(corner1, corner2, distance)
+function s:MoveHorizontally(corner_start, corner_end, distance)
     if !&modifiable
         return 0
     endif
 
-    let l:cols = [col(a:corner1), col(a:corner2)]
+    let l:cols = [col(a:corner_start), col(a:corner_end)]
     let l:first = min(l:cols)
     let l:last  = max(l:cols)
     let l:width = l:last - l:first + 1
 
     let l:before = max([1, l:first + a:distance])
     if a:distance > 0 && !g:move_past_end_of_line
-        let l:shortest = min(map(getline(a:corner1, a:corner2), 'strwidth(v:val)'))
+        let l:lines = getline(a:corner_start, a:corner_end)
+        let l:shortest = min(map(l:lines, 'strwidth(v:val)'))
         if l:last < l:shortest
             let l:before = min([l:before, l:shortest - l:width + 1])
         else

--- a/plugin/move.vim
+++ b/plugin/move.vim
@@ -115,7 +115,7 @@ function! s:MoveCharHorizontally(distance)
 endfunction
 
 "
-" In visual mode, move the selected block to the left
+" In visual mode, move the selected block horizontally.
 " Moves right (distance > 0) and left if (distance < 0).
 " Switches to visual-block mode first if another visual mode is selected.
 "
@@ -156,21 +156,26 @@ function! s:MoveBlockHorizontally(distance)
         return
     endif
 
-    let [l:old_virtualedit, &virtualedit] = [&virtualedit, 'all']
     let l:old_default_register = @"
-
     normal! d
+
+    let l:old_virtualedit = &virtualedit
+    if l:before >= virtcol('$')
+        let &virtualedit = 'all'
+    else
+        " Because of a Vim <= 8.2 bug, we must disable virtualedit in this case.
+        " See https://github.com/vim/vim/pull/6430
+        let &virtualedit = ''
+    endif
+
     execute 'normal!' . (l:before.'|')
     normal! P
 
-    let @" = l:old_default_register
     let &virtualedit = l:old_virtualedit
+    let @" = l:old_default_register
 
     " Reselect the pasted text.
-    " For some reason, `[ doesn't always point where it should -- sometimes it
-    " is off by one. Maybe it is because of the virtualedit=all? The
-    " workaround we found is to recompute the destination column by hand.
-    execute 'normal!' . (l:before.'|') . "\<C-v>`]"
+    execute "normal! g`[\<C-v>g`]"
 
 endfunction
 

--- a/plugin/move.vim
+++ b/plugin/move.vim
@@ -53,7 +53,6 @@ function s:MoveVertically(first, last, distance)
     if g:move_auto_indent
         normal! g'[=g']
     endif
-
 endfunction
 
 "
@@ -61,7 +60,6 @@ endfunction
 " The cursor stays pointing at the same character as before.
 "
 function s:MoveLineVertically(distance)
-
     let l:old_col    = col('.')
     normal! ^
     let l:old_indent = col('.')
@@ -78,10 +76,8 @@ endfunction
 " Maintains the current selection, albeit not exactly if auto_indent is on.
 "
 function s:MoveBlockVertically(distance)
-
     call s:MoveVertically("'<", "'>", a:distance)
     normal! gv
-
 endfunction
 
 
@@ -141,9 +137,7 @@ endfunction
 " In normal mode, move the character under the cursor horizontally
 "
 function s:MoveCharHorizontally(distance)
-
     call s:MoveHorizontally('.', '.', a:distance)
-
 endfunction
 
 "
@@ -152,13 +146,10 @@ endfunction
 " to the bottom right corner if it wasn't already there.
 "
 function s:MoveBlockHorizontally(distance)
-
     execute "normal! g`<\<C-v>g`>"
-
     if s:MoveHorizontally("'<", "'>", a:distance)
         execute "normal! g`[\<C-v>g`]"
     endif
-
 endfunction
 
 

--- a/plugin/move.vim
+++ b/plugin/move.vim
@@ -31,7 +31,7 @@ endif
 " Goes down if (distance > 0) and up if (distance < 0).
 " Places the cursor at last moved line.
 "
-function! s:MoveVertically(first, last, distance)
+function s:MoveVertically(first, last, distance)
     if !&modifiable
         return
     endif
@@ -57,7 +57,7 @@ endfunction
 " In normal mode, move the current line vertically.
 " The cursor stays pointing at the same character as before.
 "
-function! s:MoveLineVertically(distance)
+function s:MoveLineVertically(distance)
 
     let l:old_col    = virtcol('.')
     normal! ^
@@ -86,7 +86,7 @@ endfunction
 " In normal mode, move the character under the cursor horizontally
 " Moves right (distance > 0) and left if (distance < 0).
 "
-function! s:MoveCharHorizontally(distance)
+function s:MoveCharHorizontally(distance)
     if !&modifiable
         return
     endif
@@ -119,7 +119,7 @@ endfunction
 " Moves right (distance > 0) and left if (distance < 0).
 " Switches to visual-block mode first if another visual mode is selected.
 "
-function! s:MoveBlockHorizontally(distance)
+function s:MoveBlockHorizontally(distance)
     if !&modifiable
         return
     endif
@@ -180,11 +180,11 @@ function! s:MoveBlockHorizontally(distance)
 endfunction
 
 
-function! s:HalfPageSize()
+function s:HalfPageSize()
     return winheight('.') / 2
 endfunction
 
-function! s:MoveKey(key)
+function s:MoveKey(key)
     return '<' . g:move_key_modifier . '-' . a:key . '>'
 endfunction
 

--- a/plugin/move.vim
+++ b/plugin/move.vim
@@ -62,16 +62,15 @@ endfunction
 "
 function s:MoveLineVertically(distance)
 
-    let l:old_col    = virtcol('.')
+    let l:old_col    = col('.')
     normal! ^
-    let l:old_indent = virtcol('.')
+    let l:old_indent = col('.')
 
     call s:MoveVertically('.', '.', a:distance)
 
     normal! ^
-    let l:new_indent = virtcol('.')
-    let l:new_col    = max([1, l:old_col - l:old_indent + l:new_indent])
-    execute 'normal!'  (l:new_col . '|')
+    let l:new_indent = col('.')
+    call cursor(line('.'), max([1, l:old_col - l:old_indent + l:new_indent]))
 endfunction
 
 "
@@ -97,7 +96,7 @@ function s:MoveHorizontally(corner1, corner2, distance)
         return 0
     endif
 
-    let l:cols = [virtcol(a:corner1), virtcol(a:corner2)]
+    let l:cols = [col(a:corner1), col(a:corner2)]
     let l:first = min(l:cols)
     let l:last  = max(l:cols)
     let l:width = l:last - l:first + 1
@@ -121,7 +120,7 @@ function s:MoveHorizontally(corner1, corner2, distance)
     normal! x
 
     let l:old_virtualedit = &virtualedit
-    if l:before >= virtcol('$')
+    if l:before >= col('$')
         let &virtualedit = 'all'
     else
         " Because of a Vim <= 8.2 bug, we must disable virtualedit in this case.
@@ -129,7 +128,7 @@ function s:MoveHorizontally(corner1, corner2, distance)
         let &virtualedit = ''
     endif
 
-    execute 'normal!' . (l:before.'|')
+    call cursor(line('.'), l:before)
     normal! P
 
     let &virtualedit = l:old_virtualedit

--- a/plugin/move.vim
+++ b/plugin/move.vim
@@ -36,14 +36,17 @@ function s:MoveVertically(first, last, distance)
         return
     endif
 
+    let l:first = line(a:first)
+    let l:last  = line(a:last)
+
     " To avoid 'Invalid range' errors we must ensure that the destination
     " line is valid and that we don't try to move a range into itself.
     if a:distance <= 0
-        let l:after = max([1,         a:first + a:distance]) - 1
+        let l:after = max([1,         l:first + a:distance]) - 1
     else
-        let l:after = min([line('$'), a:last  + a:distance])
+        let l:after = min([line('$'), l:last  + a:distance])
     endif
-    execute a:first ',' a:last 'move ' l:after
+    execute l:first ',' l:last 'move ' l:after
 
     " After a :move the '[ and '] marks point to first and last moved line
     " and the cursor is placed at the last line.
@@ -63,7 +66,7 @@ function s:MoveLineVertically(distance)
     normal! ^
     let l:old_indent = virtcol('.')
 
-    call s:MoveVertically(line('.'), line('.'), a:distance)
+    call s:MoveVertically('.', '.', a:distance)
 
     normal! ^
     let l:new_indent = virtcol('.')
@@ -77,7 +80,7 @@ endfunction
 "
 function s:MoveBlockVertically(distance)
 
-    call s:MoveVertically(line("'<"), line("'>"), a:distance)
+    call s:MoveVertically("'<", "'>", a:distance)
     normal! gv
 
 endfunction

--- a/plugin/move.vim
+++ b/plugin/move.vim
@@ -145,22 +145,13 @@ function s:MoveCharHorizontally(distance)
 endfunction
 
 "
-" If in blockwise visual mode, move the selected rectangular area.
-" If in characterwise visual mode do the same, after switching to blockwise.
-" If in linewise visual mode, do nothing.
+" In visual mode, switch to blockwise mode then move the selected rectangular
+" area horizontally. Maintains the selection although the cursor may be moved
+" to the bottom right corner if it wasn't already there.
 "
 function s:MoveBlockHorizontally(distance)
 
-    normal! gv
-
-    if visualmode() ==# 'V'
-        echoerr 'vim-move: Cannot move horizontally in linewise visual mode'
-        return
-    endif
-
-    if visualmode() ==# 'v'
-        execute "normal! \<C-v>"
-    endif
+    execute "normal! g`<\<C-v>g`>"
 
     if s:MoveHorizontally("'<", "'>", a:distance)
         execute "normal! g`[\<C-v>g`]"


### PR DESCRIPTION
I gave another close look at the MoveHorizontally functions. Found a couple of bugs to fix and figured out a way to put the movement logic in a single place. That are three main changes in this PR:

1) Improved the workaround for the problem of virtualedit putting the cursor in the wrong place. Instead of fixing the cursor after virtualedit messes up its position, we now disable virtualedit in the cases it is bugged. This means that the `[` and `]` always point to the correct place and can now be used by our functions. I also reported the bug to the Vim maintainers. They quickly found out what was the problem and already have patches queued up for the next Vim release.

2) The core movement logic MoveCharHorizontally and MoveBlockHorizontally in now in a single function. The trick is that "x" does the same thing as "d" if we are in Visual mode.

3) Uses of virtcol() are replaced by col(), improving how the functions behave in the presence of tabs. See the last commit message for details.