### PR TITLE
reindent functionality cleanup

### DIFF
--- a/plugin/move.vim
+++ b/plugin/move.vim
@@ -72,10 +72,9 @@ function s:MoveVertically(first, last, distance)
         let l:last  = line("']")
 
         call cursor(l:first, 1)
-        normal! ^
-        let l:old_indent = virtcol('.')
+        let l:old_indent = indent('.')
         normal! ==
-        let l:new_indent = indent('.') + 1
+        let l:new_indent = indent('.')
 
         if l:first < l:last && l:old_indent != l:new_indent
             let l:op = (l:old_indent < l:new_indent

--- a/plugin/move.vim
+++ b/plugin/move.vim
@@ -77,14 +77,13 @@ function s:MoveVertically(first, last, distance)
         normal! ==
         let l:new_indent = indent('.') + 1
 
-        let [l:sorted_first, l:sorted_last] = sort([first, last], 'n')
         if l:first < l:last && l:old_indent != l:new_indent
             let l:op = (l:old_indent < l:new_indent
                         \  ? repeat('>', l:new_indent - l:old_indent)
                         \  : repeat('<', l:old_indent - l:new_indent))
             let l:old_sw = &shiftwidth
             let &shiftwidth = 1
-            execute l:sorted_first+1 ',' l:sorted_last l:op
+            execute l:first+1 ',' l:last l:op
             let &shiftwidth = l:old_sw
         endif
 


### PR DESCRIPTION
forgot that in #60, the sorting was not necessary like in the plugin I was making.
Simply removes the `sort([first, last], 'n')` as it no longer has purpose.