### PR TITLE
use :undojoin to merge subsequent moves into one

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,13 @@ normal mode:
 The mappings can be prefixed with a count, e.g. `5<A-k>` will move the selection
 up by 5 lines.
 
+Features:
+
+* vertical motions
+* horizontal motions
+* automatic indentation
+* undo multiple moves with single `:undo`
+
 See this short demo for a first impression:
 
 ![vim-vertical-move demo](http://i.imgur.com/RMv8KsJ.gif)

--- a/doc/move.txt
+++ b/doc/move.txt
@@ -48,6 +48,16 @@ the line. Can be disabled with >
 
     let g:move_past_end_of_line = 0
 
+By default subsequent move operations in the same direction use |:undojoin| so
+that all of them are undone after hitting |:undo| once. Can be disabled with >
+
+    let g:move_undo_join = 0
+
+It is also possible to uses |:undojoin| for all moves, regardless of motion
+direction with >
+
+    let g:move_undo_join_same_dir_only = 0
+
 -------------------------------------------------------------------------------
 2.1 <Plug>MoveBlockDown
 


### PR DESCRIPTION
Closes https://github.com/matze/vim-move/issues/7.

With these changes, after each move operation we store `b:changedtick` and the move direction. When the function is called again it checks if `b:changedtick` is still the same. If it didn't change, then `:undojoin` is called to merge the new change with the old one in undo history. The previous move direction is also compared and `:undojoin` is used only if it is the same as current move direction.