### PR TITLE
Fix #71

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,9 @@ And so on...
 Both `g:move_key_modifier` and `g:move_key_modifier_visualmode` default to 'A'
 for backwards compatibility with previous versions of vim-move.
 
+If the default mappings do not work, see the `move_normal_option` option in the
+help doc.
+
 
 ## License
 

--- a/doc/move.txt
+++ b/doc/move.txt
@@ -58,6 +58,10 @@ direction with >
 
     let g:move_undo_join_same_dir_only = 0
 
+If default bidings are not working with vim-move, try setting >
+
+    let g:move_normal_option = 1
+
 -------------------------------------------------------------------------------
 2.1 <Plug>MoveBlockDown
 

--- a/doc/move.txt
+++ b/doc/move.txt
@@ -58,7 +58,7 @@ direction with >
 
     let g:move_undo_join_same_dir_only = 0
 
-If default bidings are not working with vim-move, try setting >
+If default bindings are not working with vim-move, try setting >
 
     let g:move_normal_option = 1
 

--- a/plugin/move.vim
+++ b/plugin/move.vim
@@ -22,6 +22,10 @@ if !exists('g:move_key_modifier_visualmode')
     let g:move_key_modifier_visualmode = 'A'
 endif
 
+" Only remap option keys if the user specifies (see pull request #71)
+if !exists('g:move_normal_option')
+    let g:move_normal_option = 0
+endif
 
 if !exists('g:move_auto_indent')
     let g:move_auto_indent = 1
@@ -246,14 +250,14 @@ let s:mac_map_keys = {'k': '˚', 'j': '∆', 'h': '˙', 'l': '¬'}
 
 function s:MoveKey(key)
     " If on macOS, use the equivalent key for <A-KEY>
-    if has('macunix') && g:move_key_modifier_visualmode == 'A'
+    if g:move_normal_option && g:move_key_modifier_visualmode ==? 'A'
         return s:mac_map_keys[a:key]
     endif
     return '<' . g:move_key_modifier . '-' . a:key . '>'
 endfunction
 
 function s:VisualMoveKey(key)
-    if has('macunix') && g:move_key_modifier_visualmode == 'A'
+    if g:move_normal_option && g:move_key_modifier_visualmode ==? 'A'
         return s:mac_map_keys[a:key]
     endif
     return '<' . g:move_key_modifier_visualmode . '-' . a:key . '>'


### PR DESCRIPTION
## Problem
Some users have different terminal option key bindings, so the alt key would only work with a specific portion of users.

## Fix
Default to assuming ESC+ is sent with the alt key, and provide an option (`g:move_normal_option`) in case the user wants to use ∆ or ˚ etc.

### NOTE
Further discussion about the best way to handle the alt keys may be needed.